### PR TITLE
Set timeout on CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,7 @@ jobs:
   build:
     name: Tests
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
I can see it hangs quite often, so set a timeout to not drain CI.

refs https://github.com/rails/solid_cable/actions/runs/10842172677/job/30087374717