### PR TITLE
Remove frozen_string_literal comment from cable_schema install template

### DIFF
--- a/lib/generators/solid_cable/install/templates/db/cable_schema.rb
+++ b/lib/generators/solid_cable/install/templates/db/cable_schema.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 ActiveRecord::Schema[7.1].define(version: 1) do
   create_table "solid_cable_messages", force: :cascade do |t|
     t.binary "channel", limit: 1024, null: false


### PR DESCRIPTION
These comments should not be generated by default on a fresh installation