### PR TITLE
Fix installing Solid Queue

### DIFF
--- a/lib/generators/solid_cable/install/templates/config/cable.yml
+++ b/lib/generators/solid_cable/install/templates/config/cable.yml
@@ -1,6 +1,6 @@
 # Async adapter only works within the same process, so for manually triggering cable updates from a console,
 # and seeing results in the browser, you must do so from the web console (running inside the dev process),
-# not a terminal started via bin/rails console! Add "console" to any action or "<%= console %>" in any view
+# not a terminal started via bin/rails console! Add "console" to any action or any ERB template view
 # to make the web console appear.
 development:
   adapter: async


### PR DESCRIPTION
Previously it failed with solid_cable/lib/generators/solid_cable/install/templates/config/cable.yml:3:in template: undefined local variable or method console for an instance of SolidCable::InstallGenerator (NameError)

After adding an ERB escape, ie <%% it was having the same issue in final Rails app.