### PR TITLE
Remove duplicate routes for rooms

### DIFF
--- a/bench/config/routes.rb
+++ b/bench/config/routes.rb
@@ -2,8 +2,6 @@ Rails.application.routes.draw do
   mount ActiveError::Engine => "/errors"
   mount ActionCable.server => "/cable"
 
-  resources :rooms
-
   get "/ws" => "ws_debugger#show"
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 


### PR DESCRIPTION
Noticed that `resources :rooms` is written two times in the `bench/config/routes.rb`.