### PR TITLE
Added broadcast_list to SolidCable adapter

### DIFF
--- a/app/models/solid_cable/message.rb
+++ b/app/models/solid_cable/message.rb
@@ -6,7 +6,12 @@ module SolidCable
       where(created_at: ...::SolidCable.message_retention.ago)
     }
     scope :broadcastable, lambda { |channels, last_id|
-      where(channel_hash: channel_hashes_for(channels)).
+      where(broadcast_to_list: false).
+        where(channel_hash: channel_hashes_for(channels)).
+        where(id: (last_id + 1)..).order(:id)
+    }
+    scope :broadcastable_to_list, lambda { |channels, last_id|
+      where(broadcast_to_list: true).
         where(id: (last_id + 1)..).order(:id)
     }
 
@@ -14,6 +19,11 @@ module SolidCable
       def broadcast(channel, payload)
         insert({ created_at: Time.current, channel:, payload:,
           channel_hash: channel_hash_for(channel) })
+      end
+
+      def broadcast_list(channel, payload)
+        insert({ created_at: Time.current, channel:, payload:,
+          channel_hash: channel_hash_for(channel), broadcast_to_list: true })
       end
 
       def channel_hashes_for(channels)

--- a/bench/db/migrate/20241008221317_add_broadcast_to_list.solid_cable.rb
+++ b/bench/db/migrate/20241008221317_add_broadcast_to_list.solid_cable.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddBroadcastToList < ActiveRecord::Migration[7.2]
+  def change
+    add_column :solid_cable_messages, :broadcast_to_list, :boolean, null: false, default: false
+  end
+end

--- a/bench/db/schema.rb
+++ b/bench/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2024_09_12_235943) do
+ActiveRecord::Schema[8.0].define(version: 2024_10_08_221317) do
   create_table "active_error_faults", force: :cascade do |t|
     t.integer "cause_id"
     t.binary "backtrace", limit: 536870912
@@ -48,6 +48,7 @@ ActiveRecord::Schema[8.0].define(version: 2024_09_12_235943) do
     t.binary "payload", limit: 536870912, null: false
     t.datetime "created_at", null: false
     t.integer "channel_hash", limit: 8, null: false
+    t.boolean "broadcast_to_list", default: false, null: false
     t.index ["channel"], name: "index_solid_cable_messages_on_channel"
     t.index ["channel_hash"], name: "index_solid_cable_messages_on_channel_hash"
     t.index ["created_at"], name: "index_solid_cable_messages_on_created_at"

--- a/lib/generators/solid_cable/install/templates/db/cable_schema.rb
+++ b/lib/generators/solid_cable/install/templates/db/cable_schema.rb
@@ -4,6 +4,7 @@ ActiveRecord::Schema[7.1].define(version: 1) do
     t.binary "payload", limit: 536870912, null: false
     t.datetime "created_at", null: false
     t.integer "channel_hash", limit: 8, null: false
+    t.boolean "broadcast_to_list", default: false, null: false
     t.index ["channel"], name: "index_solid_cable_messages_on_channel"
     t.index ["channel_hash"], name: "index_solid_cable_messages_on_channel_hash"
     t.index ["created_at"], name: "index_solid_cable_messages_on_created_at"

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -16,6 +16,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_09_12_130854) do
     t.binary "payload", limit: 536870912, null: false
     t.datetime "created_at", null: false
     t.integer "channel_hash", limit: 8, null: false
+    t.boolean "broadcast_to_list", default: false, null: false
     t.index ["channel"], name: "index_solid_cable_messages_on_channel"
     t.index ["channel_hash"], name: "index_solid_cable_messages_on_channel_hash"
     t.index ["created_at"], name: "index_solid_cable_messages_on_created_at"

--- a/test/lib/action_cable/subscription_adapter/solid_cable_test.rb
+++ b/test/lib/action_cable/subscription_adapter/solid_cable_test.rb
@@ -148,6 +148,16 @@ class ActionCable::SubscriptionAdapter::SolidCableTest < ActionCable::TestCase
     end
   end
 
+  test "broadcast_list" do
+    subscribe_as_queue("channel:2-3") do |queue|
+      subscribe_as_queue("channel:3-4") do |queue2|
+        @tx_adapter.broadcast_list("channel:2", "hello world")
+        assert_empty queue2
+      end
+      assert_equal "hello world", queue.pop
+    end
+  end
+
   private
     def cable_config
       { adapter: "solid_cable", message_retention: "1.second",


### PR DESCRIPTION
I created a PR on Rails repo to introduce new methods to ActionCable API in order to broadcast a message to a list of streams : https://github.com/rails/rails/pull/52952

I thought it would be interesting to add related modifications to SolidCable so it's compliant with ActionCable, as soon as those updates are merged. (If they are!)