### PR TITLE
Wrap application code in Rails executor to prevent autoloading problems

### DIFF
--- a/lib/action_cable/subscription_adapter/solid_cable.rb
+++ b/lib/action_cable/subscription_adapter/solid_cable.rb
@@ -96,11 +96,13 @@ module ActionCable
             end
 
             def broadcast_messages
-              ::SolidCable::Message.broadcastable(channels, last_id).
-                each do |message|
-                  broadcast(message.channel, message.payload)
-                  self.last_id = message.id
+              Rails.application.reloader.wrap do
+                ::SolidCable::Message.broadcastable(channels, last_id).
+                  each do |message|
+                    broadcast(message.channel, message.payload)
+                    self.last_id = message.id
                 end
+              end
             end
 
             def with_polling_volume

--- a/test/config_stubs.rb
+++ b/test/config_stubs.rb
@@ -12,6 +12,16 @@ module ConfigStubs
     def config_for(_file)
       @config
     end
+
+    def reloader
+      @reloader ||= ReloaderStub.new
+    end
+
+    class ReloaderStub
+      def wrap(&block)
+        block.call
+      end
+    end
   end
 
   def with_cable_config(**)


### PR DESCRIPTION
Broadcasting happens from a thread and involves a `SolidCable::Message` model that is auto-reloaded by Rails in development. This can result in race conditions where the ActionCable thread tries to access the model class but it can't resolve it.

https://guides.rubyonrails.org/threading_and_code_execution.html
