### PR TITLE
Join listener thread instead of spinning

### DIFF
--- a/lib/action_cable/subscription_adapter/solid_cable.rb
+++ b/lib/action_cable/subscription_adapter/solid_cable.rb
@@ -59,7 +59,7 @@ module ActionCable
 
           def shutdown
             self.running = false
-            Thread.pass while thread.alive?
+            thread.join
           end
 
           def add_channel(channel, on_success)


### PR DESCRIPTION
Tracked down a puma process spinning at 100% CPU to this line here.

Any reason why this can't be a `thread.join` rather than spinning?