### PR TITLE
Rework concurrency control to avoid thread locks

### DIFF
--- a/test/config_stubs.rb
+++ b/test/config_stubs.rb
@@ -18,8 +18,7 @@ module ConfigStubs
     end
 
     class ExectorStub
-      def wrap(&block)
-        block.call
+      def run!
       end
     end
   end


### PR DESCRIPTION
Follow up to https://github.com/rails/solid_cable/pull/52#issuecomment-2558079300.

This patch was created by @haileys at https://github.com/rails/solid_cable/pull/52#issuecomment-2537366280. All the credit to her.

Since the error is a bit elusive, I'd like to test this patch for a while in our team to make sure the deadlock doesn't reproduce anymore.

