### PR TITLE
Don’t force cable.yml config

### DIFF
--- a/lib/generators/solid_cable/install/install_generator.rb
+++ b/lib/generators/solid_cable/install/install_generator.rb
@@ -5,6 +5,6 @@ class SolidCable::InstallGenerator < Rails::Generators::Base
 
   def copy_files
     template "db/cable_schema.rb"
-    template "config/cable.yml", force: true
+    template "config/cable.yml"
   end
 end


### PR DESCRIPTION
I was just migrating a Rails app to Solid Trifecta, and I noticed an inconsistency in the installation process. Solid Cache and Solid Queue asked me if I wanted to overwrite my existing config files, but Solid Cable did not, it replaced the already manually edited `config.yml` file without asking.

If there isn't any other reason to keep the `force` option enabled, I propose that we disable it.

Relevant files:
- [Solid Queue](https://github.com/rails/solid_queue/blob/7f50be63b46766bf29499f757128c39ebda8bb87/lib/generators/solid_queue/install/install_generator.rb#L7-L10)
- [Solid Cache](https://github.com/rails/solid_cache/blob/45cc798116cb8d5bb75d149c122f7cc56c79fce6/lib/generators/solid_cache/install/install_generator.rb#L7-L8)