### PR TITLE
Prevent broadcasting old messages when new channels are subscribed

### DIFF
--- a/app/models/solid_cable/message.rb
+++ b/app/models/solid_cable/message.rb
@@ -7,7 +7,7 @@ module SolidCable
     }
     scope :broadcastable, lambda { |channels, last_id|
       where(channel_hash: channel_hashes_for(channels)).
-        where(id: (last_id + 1)..).order(:id)
+        where(id: (last_id.to_i + 1)..).order(:id)
     }
 
     class << self


### PR DESCRIPTION
Fixes https://github.com/rails/solid_cable/issues/65