### PR TITLE
Prevent broadcasting old messages when new channels are subscribed

### DIFF
--- a/app/models/solid_cable/message.rb
+++ b/app/models/solid_cable/message.rb
@@ -7,7 +7,7 @@ module SolidCable
     }
     scope :broadcastable, lambda { |channels, last_id|
       where(channel_hash: channel_hashes_for(channels)).
-        where(id: (last_id + 1)..).order(:id)
+        where(id: (last_id.to_i + 1)..).order(:id)
     }
 
     class << self

--- a/lib/action_cable/subscription_adapter/solid_cable.rb
+++ b/lib/action_cable/subscription_adapter/solid_cable.rb
@@ -89,7 +89,7 @@ module ActionCable
           end
 
           def add_channel(channel, on_success)
-            channels.add(channel)
+            channels[channel] = last_message_id
             event_loop.post(&on_success) if on_success
           end
 
@@ -103,21 +103,22 @@ module ActionCable
 
           private
             attr_reader :event_loop, :thread
-            attr_writer :last_id
 
-            def last_id
-              @last_id ||= ::SolidCable::Message.maximum(:id) || 0
+            def last_message_id
+              ::SolidCable::Message.maximum(:id) || 0
             end
 
             def channels
-              @channels ||= Set.new
+              @channels ||= Concurrent::Hash.new
             end
 
             def broadcast_messages
-              ::SolidCable::Message.broadcastable(channels, last_id).
+              ::SolidCable::Message.broadcastable(channels.keys, channels.values.min).
                 each do |message|
-                broadcast(message.channel, message.payload)
-                self.last_id = message.id
+                if channels[message.channel].present? && channels[message.channel] < message.id
+                  broadcast(message.channel, message.payload)
+                  channels[message.channel] = message.id
+                end
               end
             end
 


### PR DESCRIPTION
Fixes https://github.com/rails/solid_cable/issues/65